### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -16,11 +16,11 @@ p6df::modules::oracle::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::oracle::external::brew()
+# Function: p6df::modules::oracle::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::oracle::external::brew() {
+p6df::modules::oracle::external::brews() {
 
   p6df::core::homebrew::cli::brew::install InstantClientTap/instantclient/instantclient-sqlplus
   p6df::core::homebrew::cli::brew::install InstantClientTap/instantclient/instantclient-tools


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly