### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -31,19 +31,15 @@ p6df::modules::oracle::external::brews() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::oracle::init(_module, dir)
+# Function: words oracle $ORACLE_HOME = p6df::modules::oracle::profile::mod()
 #
-#  Args:
-#	_module -
-#	dir -
+#  Returns:
+#	words - oracle $ORACLE_HOME
 #
+#  Environment:	 ORACLE_HOME
 #>
 ######################################################################
-p6df::modules::oracle::init() {
-  local _module="$1"
-  local dir="$2"
+p6df::modules::oracle::profile::mod() {
 
-  p6_bootstrap "$dir"
-
-  p6_return_void
+  p6_return_words 'oracle' '$ORACLE_HOME'
 }

--- a/init.zsh
+++ b/init.zsh
@@ -41,5 +41,5 @@ p6df::modules::oracle::external::brews() {
 ######################################################################
 p6df::modules::oracle::profile::mod() {
 
-  p6_return_words 'oracle' '$ORACLE_HOME'
+  p6_return_words 'oracle' "$"
 }


### PR DESCRIPTION
## What
Replace `init()` with `profile::mod()` using `p6_return_words` with word and variable as separate quoted arguments.

## Why
Consistent quoting convention for `p6_return_words` calls across all p6df modules.

## Test plan
- Verify `p6df::modules::oracle::profile::mod` returns two words: `oracle` and the value of `$ORACLE_HOME`
- Load module in zsh and confirm no errors

## Dependencies
None