### PR TITLE
fix(prompt): set ORACLE_HOME env var in profile::mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ TODO: Add a short summary of this module.
   - Args:
     - _module -
     - dir -
+- `words oracle $ORACLE_HOME = p6df::modules::oracle::profile::mod()`
 
 #### p6df-oracle/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -41,5 +41,5 @@ p6df::modules::oracle::external::brews() {
 ######################################################################
 p6df::modules::oracle::profile::mod() {
 
-  p6_return_words 'oracle' "$"
+  p6_return_words 'oracle' '$ORACLE_HOME'
 }


### PR DESCRIPTION
## What
Replace placeholder `"$"` with `'$ORACLE_HOME'` in `p6df::modules::oracle::profile::mod()` and update README.

## Why
The prompt word list was missing the actual environment variable, causing the prompt to display nothing useful.

## Test plan
- Inspected change manually

## Dependencies
None